### PR TITLE
Fix compilation error:  cannot access PropertyInfo on Jdk 11

### DIFF
--- a/src/main/java/org/agoncal/application/petstore/view/ViewUtils.java
+++ b/src/main/java/org/agoncal/application/petstore/view/ViewUtils.java
@@ -52,7 +52,7 @@ public final class ViewUtils
                   // Find a matching getter and invoke it to display the key
                   for (Method method : object.getClass().getDeclaredMethods())
                   {
-                     if (method.equals(new PropertyDescriptor(field.getName(), object.getClass()).getReadMethod()))
+                     if (method.equals(new PropertyDescriptor((String) field.getName(), object.getClass()).getReadMethod()))
                      {
                         return method.invoke(object).toString();
                      }


### PR DESCRIPTION
This project fails to compile on a machine with jdk 9+ installed, the reason is caused by this issue:

https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212636

> Since Java 9, most of the com.sun.* APIs , JDK-internal APIs are no longer accessible, this issue is reproducible in all JDK versions after JDK 8.
Output from jdk12 ea b15 :
--------------------------------------
>javac -source 1.8 -target 1.8 CompileFailure.java
warning: [options] bootstrap class path not set in conjunction with -source 8
CompileFailure.java:6: error: cannot access PropertyInfo
        new PropertyDescriptor(object.getClass().getName(), object.getClass());
        ^
  class file for com.sun.beans.introspect.PropertyInfo not found
1 error
1 warning