### PR TITLE
Fix build error

### DIFF
--- a/src/main/java/org/agoncal/application/petstore/view/ViewUtils.java
+++ b/src/main/java/org/agoncal/application/petstore/view/ViewUtils.java
@@ -52,7 +52,7 @@ public final class ViewUtils
                   // Find a matching getter and invoke it to display the key
                   for (Method method : object.getClass().getDeclaredMethods())
                   {
-                     if (method.equals(new PropertyDescriptor(field.getName(), object.getClass()).getReadMethod()))
+                     if (method.equals(new PropertyDescriptor((String)field.getName(), object.getClass()).getReadMethod()))
                      {
                         return method.invoke(object).toString();
                      }


### PR DESCRIPTION
Hi @agoncal, I'm a PM on Azure App Service. We use this repro in our JBoss EAP quickstart, and a user recently reported that the application doesn't build correctly with Java 8. This PR fixes the build error and Maven compiles correctly with this change, but I'm not sure what the root problem is. (Maybe the package changed, or the latest versions of Java 8 changed something?)

Error I get:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project petstoreee7: Compilation failure
[ERROR] /C:/Users/jafreebe/Documents/GitHub/migrate-javaee-app-to-azure-training-new/src/main/java/org/agoncal/application/petstore/view/ViewUtils.java:[55,40] cannot access com.sun.beans.introspect.PropertyInfo
[ERROR]   class file for com.sun.beans.introspect.PropertyInfo not found
```

My Java info:

```
java version "1.8.0_301"
Java(TM) SE Runtime Environment (build 1.8.0_301-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.301-b09, mixed mode)
```

Related:
- https://github.com/Azure-Samples/migrate-javaee-app-to-azure-training/pull/15
- https://github.com/MicrosoftDocs/azure-docs/issues/78650